### PR TITLE
Added a check for an edge case with null values on logs

### DIFF
--- a/src/LetsTrace/FieldExtensions.cs
+++ b/src/LetsTrace/FieldExtensions.cs
@@ -51,33 +51,38 @@ namespace LetsTrace
             if (kv.Value is byte[]) {
                 return kv.Value.ToField<byte[]>(kv.Key);
             }
-
-            var typeCode = Type.GetTypeCode(kv.Value.GetType());
-            
-            switch(typeCode)
+            if (kv.Value == null) {
+                return new Field<string> { Key = kv.Key, Value = "" };
+            }
+            else
             {
-                case TypeCode.String:
-                    return kv.Value.ToField<string>(kv.Key);
-                case TypeCode.Double:
-                    return kv.Value.ToField<double>(kv.Key);
-                case TypeCode.Decimal:
-                    return kv.Value.ToField<decimal>(kv.Key);
-                case TypeCode.Boolean:
-                    return kv.Value.ToField<bool>(kv.Key);
-                case TypeCode.UInt16:
-                    return kv.Value.ToField<ushort>(kv.Key);
-                case TypeCode.UInt32:
-                    return kv.Value.ToField<uint>(kv.Key);
-                case TypeCode.UInt64:
-                    return kv.Value.ToField<ulong>(kv.Key);
-                case TypeCode.Int16:
-                    return kv.Value.ToField<short>(kv.Key);
-                case TypeCode.Int32:
-                    return kv.Value.ToField<int>(kv.Key);
-                case TypeCode.Int64:
-                    return kv.Value.ToField<long>(kv.Key);
-                default:
-                    return new Field<string> { Key = kv.Key, Value = kv.Value.ToString() };
+                var typeCode = Type.GetTypeCode(kv.Value.GetType());
+
+                switch (typeCode)
+                {
+                    case TypeCode.String:
+                        return kv.Value.ToField<string>(kv.Key);
+                    case TypeCode.Double:
+                        return kv.Value.ToField<double>(kv.Key);
+                    case TypeCode.Decimal:
+                        return kv.Value.ToField<decimal>(kv.Key);
+                    case TypeCode.Boolean:
+                        return kv.Value.ToField<bool>(kv.Key);
+                    case TypeCode.UInt16:
+                        return kv.Value.ToField<ushort>(kv.Key);
+                    case TypeCode.UInt32:
+                        return kv.Value.ToField<uint>(kv.Key);
+                    case TypeCode.UInt64:
+                        return kv.Value.ToField<ulong>(kv.Key);
+                    case TypeCode.Int16:
+                        return kv.Value.ToField<short>(kv.Key);
+                    case TypeCode.Int32:
+                        return kv.Value.ToField<int>(kv.Key);
+                    case TypeCode.Int64:
+                        return kv.Value.ToField<long>(kv.Key);
+                    default:
+                        return new Field<string> { Key = kv.Key, Value = kv.Value.ToString() };
+                }
             }
         }
     }

--- a/src/LetsTrace/FieldExtensions.cs
+++ b/src/LetsTrace/FieldExtensions.cs
@@ -54,35 +54,32 @@ namespace LetsTrace
             if (kv.Value == null) {
                 return new Field<string> { Key = kv.Key, Value = "" };
             }
-            else
+            
+            var typeCode = Type.GetTypeCode(kv.Value.GetType());
+            switch (typeCode)
             {
-                var typeCode = Type.GetTypeCode(kv.Value.GetType());
-
-                switch (typeCode)
-                {
-                    case TypeCode.String:
-                        return kv.Value.ToField<string>(kv.Key);
-                    case TypeCode.Double:
-                        return kv.Value.ToField<double>(kv.Key);
-                    case TypeCode.Decimal:
-                        return kv.Value.ToField<decimal>(kv.Key);
-                    case TypeCode.Boolean:
-                        return kv.Value.ToField<bool>(kv.Key);
-                    case TypeCode.UInt16:
-                        return kv.Value.ToField<ushort>(kv.Key);
-                    case TypeCode.UInt32:
-                        return kv.Value.ToField<uint>(kv.Key);
-                    case TypeCode.UInt64:
-                        return kv.Value.ToField<ulong>(kv.Key);
-                    case TypeCode.Int16:
-                        return kv.Value.ToField<short>(kv.Key);
-                    case TypeCode.Int32:
-                        return kv.Value.ToField<int>(kv.Key);
-                    case TypeCode.Int64:
-                        return kv.Value.ToField<long>(kv.Key);
-                    default:
-                        return new Field<string> { Key = kv.Key, Value = kv.Value.ToString() };
-                }
+                case TypeCode.String:
+                    return kv.Value.ToField<string>(kv.Key);
+                case TypeCode.Double:
+                    return kv.Value.ToField<double>(kv.Key);
+                case TypeCode.Decimal:
+                    return kv.Value.ToField<decimal>(kv.Key);
+                case TypeCode.Boolean:
+                    return kv.Value.ToField<bool>(kv.Key);
+                case TypeCode.UInt16:
+                    return kv.Value.ToField<ushort>(kv.Key);
+                case TypeCode.UInt32:
+                    return kv.Value.ToField<uint>(kv.Key);
+                case TypeCode.UInt64:
+                    return kv.Value.ToField<ulong>(kv.Key);
+                case TypeCode.Int16:
+                    return kv.Value.ToField<short>(kv.Key);
+                case TypeCode.Int32:
+                    return kv.Value.ToField<int>(kv.Key);
+                case TypeCode.Int64:
+                    return kv.Value.ToField<long>(kv.Key);
+                default:
+                    return new Field<string> { Key = kv.Key, Value = kv.Value.ToString() };
             }
         }
     }

--- a/test/LetsTrace.Tests/FieldTests.cs
+++ b/test/LetsTrace.Tests/FieldTests.cs
@@ -31,6 +31,13 @@ namespace LetsTrace.Tests
         }
 
         [Fact]
+        public void Field_Null()
+        {
+            var field2 = new KeyValuePair<string, object>(_key, null).ToField();
+            Assert.Equal(field2.StringValue, "");
+        }
+
+        [Fact]
         public void Field_String()
         {
             var value = "HelloWorld";


### PR DESCRIPTION
Found an edge case where a null value where passed to .Log, i added a check for it, returning and empty string field when found.
Found it while using opentracing-contrib/csharp-netcore
