### PR TITLE
AddReference() must ignore null contexts; FollowsFrom no longer exists

### DIFF
--- a/src/LetsTrace/SpanBuilder.cs
+++ b/src/LetsTrace/SpanBuilder.cs
@@ -32,7 +32,10 @@ namespace LetsTrace
 
         public ISpanBuilder AddReference(string referenceType, ISpanContext referencedContext)
         {
-            _references.Add(new Reference(referenceType, referencedContext));
+            if (referencedContext != null)
+            {
+                _references.Add(new Reference(referenceType, referencedContext));
+            }
             return this;
         }
 
@@ -42,13 +45,9 @@ namespace LetsTrace
             return this;
         }
 
-        public ISpanBuilder AsChildOf(ISpan parent) => AsChildOf(parent.Context);
+        public ISpanBuilder AsChildOf(ISpan parent) => AsChildOf(parent?.Context);
 
         public ISpanBuilder AsChildOf(ISpanContext parent) => AddReference(References.ChildOf, parent);
-
-        public ISpanBuilder FollowsFrom(ISpan parent) => FollowsFrom(parent.Context);
-
-        public ISpanBuilder FollowsFrom(ISpanContext parent) => AddReference(References.FollowsFrom, parent);
 
         public IScope StartActive(bool finishSpanOnDispose)
         {
@@ -59,7 +58,7 @@ namespace LetsTrace
 
             return _tracer.ScopeManager.Activate(Start(), finishSpanOnDispose);
         }
-        
+
         public ISpan Start()
         {
             SpanContext parent = null;
@@ -71,8 +70,8 @@ namespace LetsTrace
                 }
             }
 
-            var spanContext = parent != null 
-                ? CreateRootSpanContext(parent) 
+            var spanContext = parent != null
+                ? CreateRootSpanContext(parent)
                 : CreateChildSpanContext();
 
             var span = new Span(_tracer, _operationName, spanContext, _startTimestamp, _tags, _references);

--- a/test/LetsTrace.Tests/SpanBuilderTests.cs
+++ b/test/LetsTrace.Tests/SpanBuilderTests.cs
@@ -53,7 +53,7 @@ namespace LetsTrace.Tests
             var sampler = Substitute.For<ISampler>();
             var metrics = Substitute.For<IMetrics>();
             sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
-            
+
             var refContext = Substitute.For<ILetsTraceSpanContext>();
             var expectedReferences = new List<Reference> {
                 new Reference(References.FollowsFrom, refContext)
@@ -121,7 +121,7 @@ namespace LetsTrace.Tests
             var sampler = Substitute.For<ISampler>();
             var metrics = Substitute.For<IMetrics>();
             sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
-            
+
             var expectedTags = new Dictionary<string, object> {
                 { "boolkey", true },
                 { "doublekey", 3D },
@@ -154,7 +154,7 @@ namespace LetsTrace.Tests
             var sampler = Substitute.For<ISampler>();
             var metrics = Substitute.For<IMetrics>();
             sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
-            
+
             var refContext = Substitute.For<ILetsTraceSpanContext>();
             var expectedReferences = new List<Reference> {
                 new Reference(References.ChildOf, refContext)
@@ -176,7 +176,7 @@ namespace LetsTrace.Tests
             var sampler = Substitute.For<ISampler>();
             var metrics = Substitute.For<IMetrics>();
             sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
-            
+
             var refContext = Substitute.For<ILetsTraceSpanContext>();
             var expectedReferences = new List<Reference> {
                 new Reference(References.ChildOf, refContext)
@@ -184,49 +184,6 @@ namespace LetsTrace.Tests
 
             var sb = new SpanBuilder(tracer, operationName, sampler, metrics);
             sb.AsChildOf(refContext);
-            var builtSpan = (ILetsTraceSpan)sb.Start();
-
-            Assert.Equal(expectedReferences, builtSpan.References);
-        }
-
-        [Fact]
-        public void SpanBuilder_FollowsFrom_UsingSpan_ShouldAddReference()
-        {
-            var tracer = Substitute.For<ILetsTraceTracer>();
-            var operationName = "testing";
-            var sampler = Substitute.For<ISampler>();
-            var metrics = Substitute.For<IMetrics>();
-            sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
-            
-            var refContext = Substitute.For<ILetsTraceSpanContext>();
-            var expectedReferences = new List<Reference> {
-                new Reference(References.FollowsFrom, refContext)
-            };
-            var parentSpan = new Span(tracer, operationName, refContext);
-
-            var sb = new SpanBuilder(tracer, operationName, sampler, metrics);
-            sb.FollowsFrom(parentSpan);
-            var builtSpan = (ILetsTraceSpan)sb.Start();
-
-            Assert.Equal(expectedReferences, builtSpan.References);
-        }
-
-        [Fact]
-        public void SpanBuilder_FollowsFrom_UsingSpanContext_ShouldAddReference()
-        {
-            var tracer = Substitute.For<ILetsTraceTracer>();
-            var operationName = "testing";
-            var sampler = Substitute.For<ISampler>();
-            var metrics = Substitute.For<IMetrics>();
-            sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
-            
-            var refContext = Substitute.For<ILetsTraceSpanContext>();
-            var expectedReferences = new List<Reference> {
-                new Reference(References.FollowsFrom, refContext)
-            };
-
-            var sb = new SpanBuilder(tracer, operationName, sampler, metrics);
-            sb.FollowsFrom(refContext);
             var builtSpan = (ILetsTraceSpan)sb.Start();
 
             Assert.Equal(expectedReferences, builtSpan.References);
@@ -442,7 +399,7 @@ namespace LetsTrace.Tests
 
             var refContext = Substitute.For<ILetsTraceSpanContext>();
             var sb = new SpanBuilder(tracer, operationName, sampler, metrics);
-            sb.FollowsFrom(refContext);
+            sb.AddReference(References.FollowsFrom, refContext);
             var scope = sb.StartActive(true);
 
             scopeManager.Received(1).Activate(

--- a/test/LetsTrace.Tests/SpanBuilderTests.cs
+++ b/test/LetsTrace.Tests/SpanBuilderTests.cs
@@ -46,6 +46,23 @@ namespace LetsTrace.Tests
         }
 
         [Fact]
+        public void SpanBuilder_AddReference_IgnoresNullContext()
+        {
+            var tracer = Substitute.For<ILetsTraceTracer>();
+            var operationName = "testing";
+            var sampler = Substitute.For<ISampler>();
+            var metrics = Substitute.For<IMetrics>();
+            tracer.ActiveSpan.Returns((ISpan)null);
+            sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
+
+            var sb = new SpanBuilder(tracer, operationName, sampler, metrics);
+            sb.AddReference(References.ChildOf, null);
+            var builtSpan = (ILetsTraceSpan)sb.Start();
+
+            Assert.Empty(builtSpan.References);
+        }
+
+        [Fact]
         public void SpanBuilder_AddReference_ShouldAddReference()
         {
             var tracer = Substitute.For<ILetsTraceTracer>();
@@ -144,6 +161,40 @@ namespace LetsTrace.Tests
             Assert.Equal(expectedTags["intkey"], builtSpan.Tags["intkey"].ValueAs<int>());
             Assert.True(builtSpan.Tags["stringkey"] is Field<string>);
             Assert.Equal(expectedTags["stringkey"], builtSpan.Tags["stringkey"].ValueAs<string>());
+        }
+
+        [Fact]
+        public void SpanBuilder_AsChildOf_IgnoresNullSpan()
+        {
+            var tracer = Substitute.For<ILetsTraceTracer>();
+            var operationName = "testing";
+            var sampler = Substitute.For<ISampler>();
+            var metrics = Substitute.For<IMetrics>();
+            tracer.ActiveSpan.Returns((ISpan)null);
+            sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
+
+            var sb = new SpanBuilder(tracer, operationName, sampler, metrics);
+            sb.AsChildOf((ISpan)null);
+            var builtSpan = (ILetsTraceSpan)sb.Start();
+
+            Assert.Empty(builtSpan.References);
+        }
+
+        [Fact]
+        public void SpanBuilder_AsChildOf_IgnoresNullContext()
+        {
+            var tracer = Substitute.For<ILetsTraceTracer>();
+            var operationName = "testing";
+            var sampler = Substitute.For<ISampler>();
+            var metrics = Substitute.For<IMetrics>();
+            tracer.ActiveSpan.Returns((ISpan)null);
+            sampler.IsSampled(Arg.Any<TraceId>(), Arg.Any<string>()).Returns((false, new Dictionary<string, Field>()));
+
+            var sb = new SpanBuilder(tracer, operationName, sampler, metrics);
+            sb.AsChildOf((ISpanContext)null);
+            var builtSpan = (ILetsTraceSpan)sb.Start();
+
+            Assert.Empty(builtSpan.References);
         }
 
         [Fact]


### PR DESCRIPTION
* `AddReference` / `AsChildOf` must ignore calls with null spans/contexts.
* I've also removed the `FollowsFrom` methods as they currently don't exist on the `ISpanBuilder` interface.