### PR TITLE
Shared Project settings; SourceLink; XML docs, TreatWarningsAsErrors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+  <PropertyGroup>
+    <PackageVersion>0.0.4</PackageVersion>
+
+    <Authors>Chatham Financial Corp.</Authors>
+    <Copyright>Copyright 2018 (c) Chatham Financial Corp. All rights reserved.</Copyright>
+    <PackageProjectUrl>https://github.com/Chatham/LetsTrace</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/Chatham/LetsTrace/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageReleaseNotes>https://github.com/Chatham/LetsTrace/releases</PackageReleaseNotes>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/Chatham/LetsTrace</RepositoryUrl>
+
+    <!-- Projects that should generate nupkg files override this -->
+    <IsPackable>false</IsPackable>
+
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- SourceLink support -->
+    <DebugType>portable</DebugType>
+    <SourceLinkNoAutoLF>true</SourceLinkNoAutoLF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.8.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/LetsTrace/LetsTrace.csproj
+++ b/src/LetsTrace/LetsTrace.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-
-    <PackageId>LetsTrace</PackageId>
-    <PackageProjectUrl>https://github.com/Chatham/LetsTrace/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/Chatham/LetsTrace/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageVersion>0.0.4</PackageVersion>
     <PackageTags>letstrace;tracing;opentracing</PackageTags>
-    <Authors>Chatham Financial Corp.</Authors>
     <Description>.NET Tracing</Description>
-    <Copyright>Copyright 2018 (c) Chatham Financial Corp. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/LetsTrace/Samplers/RemoteControlledSampler.cs
+++ b/src/LetsTrace/Samplers/RemoteControlledSampler.cs
@@ -24,21 +24,21 @@ namespace LetsTrace.Samplers
         private readonly Task _pollTimer;
 
         private RemoteControlledSampler(
-            string serviceName, 
+            string serviceName,
             ISamplingManager samplingManager,
-            ILoggerFactory loggerFactory, 
-            IMetrics metrics, 
+            ILoggerFactory loggerFactory,
+            IMetrics metrics,
             ISampler sampler,
             int pollingIntervalMs)
         : this(serviceName, samplingManager, loggerFactory, metrics, sampler, new SamplerFactory(), pollingIntervalMs, PollTimer)
         {}
 
         internal RemoteControlledSampler(
-            string serviceName, 
-            ISamplingManager samplingManager, 
-            ILoggerFactory loggerFactory, 
-            IMetrics metrics, 
-            ISampler sampler, 
+            string serviceName,
+            ISamplingManager samplingManager,
+            ILoggerFactory loggerFactory,
+            IMetrics metrics,
+            ISampler sampler,
             ISamplerFactory samplerFactory,
             int pollingIntervalMs,
             Func<Action, int, CancellationToken, Task> pollTimer)
@@ -142,7 +142,7 @@ namespace LetsTrace.Samplers
         internal void UpdateRateLimitingSampler(RateLimitingSamplingStrategy strategy)
         {
             var sampler = _samplerFactory.NewRateLimitingSampler(strategy.MaxTracesPerSecond);
-            
+
             SetSamplerIfNotTheSame(sampler);
         }
 
@@ -159,7 +159,7 @@ namespace LetsTrace.Samplers
                 }
                 else
                 {
-                    _sampler = _samplerFactory.NewPerOperationSampler(_maxOperations, 
+                    _sampler = _samplerFactory.NewPerOperationSampler(_maxOperations,
                         samplingParameters.DefaultSamplingProbability,
                         samplingParameters.DefaultLowerBoundTracesPerSecond,
                         _loggerFactory);
@@ -191,6 +191,11 @@ namespace LetsTrace.Samplers
             }
 
             return false;
+        }
+        public override int GetHashCode()
+        {
+            // TODO Do we need special handling here? (see Equals handling)
+            return base.GetHashCode();
         }
 
         public sealed class Builder

--- a/test/LetsTrace.Tests/Samplers/RemoteControlledSamplerTests.cs
+++ b/test/LetsTrace.Tests/Samplers/RemoteControlledSamplerTests.cs
@@ -40,12 +40,12 @@ namespace LetsTrace.Tests.Samplers
             _mockLoggerFactory.CreateLogger<RemoteControlledSampler>().Returns(_mockLogger);
 
             _testingSampler = new RemoteControlledSampler(
-                _serivceName, 
-                _mockSamplingManager, 
-                _mockLoggerFactory, 
-                _mockMetrics, 
-                _mockSampler, 
-                _mockSamplerFactory, 
+                _serivceName,
+                _mockSamplingManager,
+                _mockLoggerFactory,
+                _mockMetrics,
+                _mockSampler,
+                _mockSamplerFactory,
                 _pollingIntervalMs,
                 _mockPollTimer
             );
@@ -189,7 +189,7 @@ namespace LetsTrace.Tests.Samplers
         [Fact]
         public void UpdateSampler_ShouldHandleNoMatchingStrategy()
         {
-            var expectedLogMessage = "No strategy present in response. Not updating sampler.";
+            //var expectedLogMessage = "No strategy present in response. Not updating sampler.";
             var ssResponse = new SamplingStrategyResponse();
             _mockSamplingManager.GetSamplingStrategy(Arg.Is<string>(sn => sn == _serivceName)).Returns(ssResponse);
 

--- a/test/LetsTrace.Tests/TracerBuilderTests.cs
+++ b/test/LetsTrace.Tests/TracerBuilderTests.cs
@@ -17,7 +17,6 @@ namespace LetsTrace.Tests
     {
         private readonly Tracer.Builder _baseBuilder;
         private readonly IReporter _mockReporter;
-        private readonly string _operationName;
         private readonly string _serviceName;
         private readonly ISampler _mockSampler;
         private readonly IScopeManager _mockScopeManager;
@@ -28,7 +27,6 @@ namespace LetsTrace.Tests
         public TracerBuilderTests()
         {
             _mockReporter = Substitute.For<IReporter>();
-            _operationName = "GET::api/values/";
             _serviceName = "testingService";
             _mockSampler = Substitute.For<ISampler>();
             _mockScopeManager = Substitute.For<IScopeManager>();
@@ -129,7 +127,7 @@ namespace LetsTrace.Tests
 
             Assert.Equal(samplingManager, ((RemoteControlledSampler)tracer.Sampler)._samplingManager);
         }
-        
+
         [Fact]
         public void Builder_WithMetricsFactory_ShouldCallCreateMetrics()
         {


### PR DESCRIPTION
This adds a few infrastructure-related features:

* Directory.Build.props files for sharing common settings
* Enables TreatWarningsAsErrors and enabled latest C# version features (which we might need - e.g. readonly structs)
  * There was a warning with an override for Equals but not for GetHashCode. I'm not sure what the correct implementation is here as the Equals code is quite complex.
* Generates XML docs for all projects in \src
* Adds [SourceLink](https://github.com/ctaggart/SourceLink) support for all projects in \src 
  * This allows people to easily debug into the source code. This project is already part of the .NET Foundation and will probably be integrated directly into msbuild at some point.

The diff also contains some whitespace fixes... hope that's ok (VS Code automatically does that).