### PR TITLE
Fixes xunit warning which is now an error and breaks the build

### DIFF
--- a/test/LetsTrace.Tests/FieldTests.cs
+++ b/test/LetsTrace.Tests/FieldTests.cs
@@ -34,7 +34,7 @@ namespace LetsTrace.Tests
         public void Field_Null()
         {
             var field2 = new KeyValuePair<string, object>(_key, null).ToField();
-            Assert.Equal(field2.StringValue, "");
+            Assert.Equal("", field2.StringValue);
         }
 
         [Fact]


### PR DESCRIPTION
See latest [AppVeyor build output](https://ci.appveyor.com/project/chatham/letstrace/build/0.0.4-22-master#L118).

This probably is due to the introduction of TreatWarningsAsErrors=true.