### PR TITLE
Performance optimization for "AddReference" handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,6 @@ config.ps1
 
 # VS generated files
 launchSettings.json
+
+# BenchmarkDotNet
+BenchmarkDotNet.Artifacts/

--- a/LetsTrace.sln
+++ b/LetsTrace.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -10,6 +10,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{F4DBFB49-2F67-49B0-A60F-E8ED78ACF550}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetsTrace.Tests", "test\LetsTrace.Tests\LetsTrace.Tests.csproj", "{5F1C7EB5-98A6-48C8-9F35-2A296148FD01}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{6663429B-6376-4317-8310-C3E15CF7D491}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LetsTrace.Benchmarks", "benchmarks\LetsTrace.Benchmarks\LetsTrace.Benchmarks.csproj", "{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,9 +52,22 @@ Global
 		{5F1C7EB5-98A6-48C8-9F35-2A296148FD01}.Release|x64.Build.0 = Release|x64
 		{5F1C7EB5-98A6-48C8-9F35-2A296148FD01}.Release|x86.ActiveCfg = Release|x86
 		{5F1C7EB5-98A6-48C8-9F35-2A296148FD01}.Release|x86.Build.0 = Release|x86
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Debug|x64.Build.0 = Debug|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Debug|x86.Build.0 = Debug|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Release|x64.ActiveCfg = Release|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Release|x64.Build.0 = Release|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Release|x86.ActiveCfg = Release|Any CPU
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B0B20678-3793-4DAE-AD7D-096BF0CEADF6} = {4FB0DAC9-D8C6-4368-B48E-363FA85029A4}
 		{5F1C7EB5-98A6-48C8-9F35-2A296148FD01} = {F4DBFB49-2F67-49B0-A60F-E8ED78ACF550}
+		{79DCD3B4-4FE7-4C15-B5B8-8498F0E13E78} = {6663429B-6376-4317-8310-C3E15CF7D491}
 	EndGlobalSection
 EndGlobal

--- a/benchmarks/LetsTrace.Benchmarks/LetsTrace.Benchmarks.csproj
+++ b/benchmarks/LetsTrace.Benchmarks/LetsTrace.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/LetsTrace.Benchmarks/LetsTrace.Benchmarks.csproj
+++ b/benchmarks/LetsTrace.Benchmarks/LetsTrace.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LetsTrace\LetsTrace.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/LetsTrace.Benchmarks/Program.cs
+++ b/benchmarks/LetsTrace.Benchmarks/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+
+namespace LetsTrace.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}

--- a/benchmarks/LetsTrace.Benchmarks/SpanBuilderBenchmark.cs
+++ b/benchmarks/LetsTrace.Benchmarks/SpanBuilderBenchmark.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Attributes;
+using OpenTracing;
+
+namespace LetsTrace.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class SpanBuilderBenchmark
+    {
+        private readonly Tracer _tracer;
+        private readonly ISpan _ref1;
+        private readonly ISpan _ref2;
+
+        public SpanBuilderBenchmark()
+        {
+            _tracer = new Tracer.Builder("service").Build();
+
+            _ref1 = _tracer.BuildSpan("ref1").Start();
+            _ref2 = _tracer.BuildSpan("ref2").Start();
+        }
+
+        [Benchmark]
+        public void Start_No_Reference()
+        {
+            _tracer.BuildSpan("foo").Start();
+        }
+
+        [Benchmark]
+        public void Start_One_Reference()
+        {
+            _tracer.BuildSpan("foo")
+                .AsChildOf(_ref1)
+                .Start();
+        }
+
+        [Benchmark]
+        public void Start_Two_References()
+        {
+            _tracer.BuildSpan("foo")
+                .AsChildOf(_ref1)
+                .AsChildOf(_ref2)
+                .Start();
+        }
+    }
+}

--- a/src/LetsTrace/ILetsTraceSpan.cs
+++ b/src/LetsTrace/ILetsTraceSpan.cs
@@ -11,7 +11,7 @@ namespace LetsTrace
         DateTimeOffset? FinishTimestamp { get; }
         List<LogRecord> Logs { get; }
         string OperationName { get; }
-        List<Reference> References { get; }
+        IEnumerable<Reference> References { get; }
         DateTimeOffset StartTimestamp { get; }
         Dictionary<string, Field> Tags { get; }
         [JsonIgnore] ILetsTraceTracer Tracer { get; }

--- a/src/LetsTrace/Span.cs
+++ b/src/LetsTrace/Span.cs
@@ -22,7 +22,7 @@ namespace LetsTrace
         // context that is given to it needs to already have determined who the
         // parent is (if there is one). The span should not handle determining
         // who its parent is
-        public List<Reference> References { get; }
+        public IEnumerable<Reference> References { get; }
         public DateTimeOffset StartTimestamp { get; }
         public Dictionary<string, Field> Tags { get; }
         public ILetsTraceTracer Tracer { get; }
@@ -41,7 +41,7 @@ namespace LetsTrace
             Context = context ?? throw new ArgumentNullException(nameof(context));
             StartTimestamp = startTimestamp ?? Tracer.Clock.CurrentTime();
             Tags = tags ?? new Dictionary<string, Field>();
-            References = references ?? new List<Reference>();
+            References = references ?? Enumerable.Empty<Reference>();
         }
 
         public void Dispose() => Finish();


### PR DESCRIPTION
This PR optimizes the handling of span references:
* No allocation required if the span has no reference
* Less allocations for when the span has one reference
* Downside: Slightly worse performance for when the span has multiple references, but this is a rare case anyway.

I also added a BenchmarkDotNet test project which should be useful in the future and I compared my changes:

#### Before
``` ini
BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Intel Core i5-4300U CPU 1.90GHz (Haswell), 1 CPU, 4 logical cores and 2 physical cores
Frequency=2435766 Hz, Resolution=410.5485 ns, Timer=TSC
.NET Core SDK=2.1.300-preview1-008174
  [Host]     : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT
```
|               Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
|--------------------- |---------:|----------:|----------:|-------:|----------:|
|   Start_No_Reference | 843.7 ns | 11.827 ns | 11.063 ns | 0.5283 |     832 B |
|  Start_One_Reference | 586.3 ns | 10.410 ns |  9.228 ns | 0.4063 |     640 B |
| Start_Two_References | 593.2 ns |  9.583 ns |  8.964 ns | 0.4063 |     640 B |

#### After 
``` ini
BenchmarkDotNet=v0.10.13, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.309)
Intel Core i5-4300U CPU 1.90GHz (Haswell), 1 CPU, 4 logical cores and 2 physical cores
Frequency=2435766 Hz, Resolution=410.5485 ns, Timer=TSC
.NET Core SDK=2.1.300-preview1-008174
  [Host]     : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT
```
|               Method |     Mean |    Error |    StdDev |  Gen 0 | Allocated |
|--------------------- |---------:|---------:|----------:|-------:|----------:|
|   Start_No_Reference | 808.9 ns | 10.39 ns |  9.715 ns | 0.5026 |     792 B |
|  Start_One_Reference | 560.0 ns | 10.51 ns |  9.318 ns | 0.3757 |     592 B |
| Start_Two_References | 628.4 ns | 11.70 ns | 11.488 ns | 0.4110 |     648 B |

This is similar to how it is implemented [jaeger-client-java](https://github.com/jaegertracing/jaeger-client-java/blob/d69c2d3333da79d7eb1ffdf982186de5b5f1f4bc/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java#L248)