### PR TITLE
Adds a build script

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion>0.0.4</PackageVersion>
+    <VersionPrefix>0.0.4</VersionPrefix>
 
     <Authors>Chatham Financial Corp.</Authors>
     <Copyright>Copyright 2018 (c) Chatham Financial Corp. All rights reserved.</Copyright>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # CI Build number is incremental and not related to actual version number of the product
-version: {build}
+version: '{build}'
 
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,42 +1,39 @@
-version: 0.0.4-{build}-{branch}
-configuration: Release
+# CI Build number is incremental and not related to actual version number of the product
+version: {build}
+
 pull_requests:
   do_not_increment_build_number: true
+
 nuget:
   account_feed: true
   project_feed: true
   disable_publish_on_pr: true
-environment:
-  PACKAGE_VERSION: 0.0.4
 
 cache:
 - C:\ProgramData\chocolatey\bin -> appveyor.yml
 - C:\ProgramData\chocolatey\lib -> appveyor.yml
 - '%USERPROFILE%\.nuget\packages -> **\project.json'
 
-init:
-- ps: $Env:LABEL = "CI" + $Env:APPVEYOR_BUILD_NUMBER.PadLeft(4, "0")
+environment:
+  global:
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
-before_build:
-- appveyor-retry dotnet restore
 build_script:
-- dotnet build .\src\LetsTrace -c %CONFIGURATION% --no-dependencies --version-suffix %LABEL%
-after_build:
-- dotnet pack .\src\LetsTrace -c %CONFIGURATION% --no-build --version-suffix %LABEL% -o artifacts
+  - ps: |
+        if ($env:APPVEYOR_REPO_TAG -eq $true) {
+            $VersionSuffix = ""
+        }
+        else {
+            $VersionSuffix = "ci" + $env:APPVEYOR_BUILD_NUMBER.PadLeft(4, "0") + "-" + $env:APPVEYOR_REPO_BRANCH.Replace("/", "-")
+        }
+  - ps: .\build.ps1 -VersionSuffix $VersionSuffix
 
-test_script:
-- dotnet test .\test\LetsTrace.Tests --configuration %CONFIGURATION%
+test: off
 
 artifacts:
-- path: .\**\artifacts\*.*
+- path: artifacts\nuget\*.nupkg
   name: NuGet
-
-dotnet_csproj:
-  patch: true
-  file: '**\*.csproj'
-  version: $(APPVEYOR_BUILD_VERSION)
-  package_version: $(PACKAGE_VERSION)
-  assembly_version: $(APPVEYOR_BUILD_VERSION)
 
 deploy:
 - provider: NuGet

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    [string] $VersionSuffix = "loc" + ((Get-Date).ToUniversalTime().ToString("yyyyMMddHHmm")),
+    [string] $ArtifactsPath = (Join-Path $PWD "artifacts"),
+    [string] $BuildConfiguration = "Release",
+
+    [bool] $RunBuild = $true,
+    [bool] $RunTests = $true
+)
+
+$ErrorActionPreference = "Stop"
+$Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
+function Task {
+    [CmdletBinding()] param (
+        [Parameter(Mandatory = $true)] [string] $name,
+        [Parameter(Mandatory = $false)] [bool] $runTask,
+        [Parameter(Mandatory = $false)] [scriptblock] $cmd
+    )
+
+    if ($cmd -eq $null) {
+        throw "Command is missing for task '$name'. Make sure the starting '{' is on the same line as the term 'Task'. E.g. 'Task `"$name`" `$Run$name {'"
+    }
+
+    if ($runTask -eq $true) {
+        Write-Host "`n------------------------- [$name] -------------------------`n" -ForegroundColor Cyan
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        & $cmd
+        Write-Host "`nTask '$name' finished in $($sw.Elapsed.TotalSeconds) sec."
+    }
+    else {
+        Write-Host "`n------------------ Skipping task '$name' ------------------" -ForegroundColor Yellow
+    }
+}
+
+
+Task "Init" $true {
+
+    if ($ArtifactsPath -eq $null) { "Property 'ArtifactsPath' may not be null." }
+    if ($BuildConfiguration -eq $null) { throw "Property 'BuildConfiguration' may not be null." }
+    if ((Get-Command "dotnet" -ErrorAction SilentlyContinue) -eq $null) { throw "'dotnet' command not found. Is .NET Core SDK installed?" }
+
+    Write-Host "VersionSuffix: $VersionSuffix"
+    Write-Host "ArtifactsPath: $ArtifactsPath"
+    Write-Host "BuildConfiguration: $BuildConfiguration"
+    Write-Host ".NET Core SDK: $(dotnet --version)`n"
+
+    Remove-Item -Path $ArtifactsPath -Recurse -Force -ErrorAction Ignore
+    New-Item $ArtifactsPath -ItemType Directory -ErrorAction Ignore | Out-Null
+    Write-Host "Created artifacts folder '$ArtifactsPath'"
+}
+
+Task "Build" $RunBuild {
+
+    dotnet msbuild "/t:Restore;Build;Pack" "/p:CI=true" `
+        "/p:Configuration=$BuildConfiguration" `
+        "/p:VersionSuffix=$VersionSuffix" `
+        "/p:PackageOutputPath=$(Join-Path $ArtifactsPath "nuget")"
+
+    if ($LASTEXITCODE -ne 0) { throw "Build failed." }
+}
+
+Task "Tests" $RunTests {
+
+    $testsFailed = $false
+    Get-ChildItem -Filter *.csproj -Recurse | ForEach-Object {
+
+        if (Select-Xml -Path $_.FullName -XPath "/Project/ItemGroup/PackageReference[@Include='Microsoft.NET.Test.Sdk']") {
+            dotnet test $_.FullName -c $BuildConfiguration --no-build
+            if ($LASTEXITCODE -ne 0) { $testsFailed = $true }
+        }
+    }
+
+    if ($testsFailed) { throw "At least one test failed." }
+}
+
+Write-Host "`nBuild finished in $($Stopwatch.Elapsed.TotalSeconds) sec." -ForegroundColor Green


### PR DESCRIPTION
Resolves #20.

* There's now **only one place** where you have to update your version number after a release (Directory.Build.props). However, AppVeyor now no longer uses this number. I can change this back if you want.
* The script can be executed locally with `.\build.ps1` and you can use the parameters `-RunBuild $true` & `-RunTests $true` to e.g. not run tests etc.
* AppVeyor runs this script as well so there's only one place where the build pipeline is defined.
* AppVeyor sets a `VersionSuffix` if it is a regular commit/PR and it does NOT set it if it is a release (a git tag)

Just let me know if yo don't like something here!!