### PR TITLE
Version bump; ignore artifacts folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,5 +272,9 @@ config.ps1
 # VS generated files
 launchSettings.json
 
+
+# Release Artifacts
+artifacts/
+
 # BenchmarkDotNet
 BenchmarkDotNet.Artifacts/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.0.4</VersionPrefix>
+    <VersionPrefix>0.0.5</VersionPrefix>
 
     <Authors>Chatham Financial Corp.</Authors>
     <Copyright>Copyright 2018 (c) Chatham Financial Corp. All rights reserved.</Copyright>


### PR DESCRIPTION
* 0.0.4 has already been released so all new builds should already have a higher version number.
* Added a general gitignore for the `artifacts/` folder so that nothing gets committed if someone e.g. extracts a nuget package for debugging cases.