### PR TITLE
Adding the branch name to NuGet packages is too error-prone

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ build_script:
             $VersionSuffix = ""
         }
         else {
-            $VersionSuffix = "ci" + $env:APPVEYOR_BUILD_NUMBER.PadLeft(4, "0") + "-" + $env:APPVEYOR_REPO_BRANCH.Replace("/", "-")
+            $VersionSuffix = "ci" + $env:APPVEYOR_BUILD_NUMBER.PadLeft(4, "0")
         }
   - ps: .\build.ps1 -VersionSuffix $VersionSuffix
 


### PR DESCRIPTION
See failing build due to invalid characters in branch name: https://ci.appveyor.com/project/chatham/letstrace/build/31-ndaslsvr

I guess it's better/easier if the package version number only contains the build number. So this re-activates the behavior from the old AppVeyor script.